### PR TITLE
kenzo: Ship prebuilt wcnss_service

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -859,4 +859,4 @@ vendor/lib/libTimeService.so
 
 # WiFi
 bin/cnss-daemon
-lib64/libwcnss_qmi.so
+bin/wcnss_service


### PR DESCRIPTION
* Xiaomi sets wifi mac using the qcom proprietary code present in this.

Change-Id: Ic3e2df510ab211e7d1e0f17d5593b5e132049477