### PR TITLE
kenzo: Blacklist fingerprint HAL key events

### DIFF
--- a/keylayout/uinput-fpc.kl
+++ b/keylayout/uinput-fpc.kl
@@ -8,7 +8,7 @@
 # as published by the Free Software Foundation.
 #
 
-key 96  CAMERA
+#key 96    DPAD_CENTER
 #key 102   HOME
 #key 105   DPAD_LEFT
 #key 106   DPAD_RIGHT


### PR DESCRIPTION
 * The newly released fingerprint HAL sends KEY_KPENTER (keycode 96)
   when fingerprint reader is tapped and device is unlocked.
   This is not useful at all, so disable it for now.

Change-Id: I694a7e69634808707ac30f8726e41ab2d621a426